### PR TITLE
Undoing the change to return data.hits.hits which is hugely breaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ module.exports = function(client, logger, _opConfig) {
                         }
                         else {
                             if (config.full_response) {
-                                resolve(data.hits.hits)
+                                resolve(data)
                             }
                             else {
                                 resolve(_.map(data.hits.hits, function(hit) {


### PR DESCRIPTION

I have no idea why such a fundamental breaking change was included in a PR that didn't even mention the change. 