### PR TITLE
Switching error_parser dependency to the npm tracked version 

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const Promise = require('bluebird');
 const _ = require('lodash');
-const parseError = require('error_parser');
+const parseError = require('@terascope/error-parser');
 
 const DOCUMENT_EXISTS = 409;
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/terascope/elasticsearch_api#readme",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "error_parser": "terascope/error_parser",
+    "@terascope/error-parser": "^1.0.0",
     "lodash": "^4.17.4",
     "uuid": "^3.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,6 +82,12 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
+"@terascope/error-parser@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@terascope/error-parser/-/error-parser-1.0.0.tgz#0853b6d10845babda7a7ed596632f866d2fde86d"
+  dependencies:
+    lodash "^4.17.4"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -652,12 +658,6 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
-
-error_parser@terascope/error_parser:
-  version "1.0.0"
-  resolved "https://codeload.github.com/terascope/error_parser/tar.gz/8ae70454aa00548af250a2a3abfc294910681121"
-  dependencies:
-    lodash "^4.17.4"
 
 es-abstract@^1.7.0:
   version "1.12.0"


### PR DESCRIPTION

Hopefully this will allow teraslice to install using npm install.